### PR TITLE
Some latest changes

### DIFF
--- a/WzComparerR2.Avatar/UI/AvatarForm.cs
+++ b/WzComparerR2.Avatar/UI/AvatarForm.cs
@@ -1828,7 +1828,7 @@ namespace WzComparerR2.Avatar.UI
                             if (i == aniActIndex)
                             {
                                 actionIndices[i] = act[fIdx].index;
-                                delay = act[i].actionFrame.AbsoluteDelay;
+                                delay = act[fIdx].actionFrame.AbsoluteDelay;
                             }
                             else if (act != null)
                             {

--- a/WzComparerR2.Common/CharaSim/ItemStringHelper.cs
+++ b/WzComparerR2.Common/CharaSim/ItemStringHelper.cs
@@ -665,8 +665,8 @@ namespace WzComparerR2.CharaSim
                 case GearType.arcaneSymbol: return "Arcane Symbol";
                 case GearType.authenticSymbol: return "Sacred Symbol";
                 case GearType.grandAuthenticSymbol: return "Grand Sacred Symbol";
-                case GearType.boxingCannon: return "拳封";//Mo Xuan weapon
-                case GearType.boxingSky: return "拳天";//Mo Xuan weapon
+                case GearType.boxingCannon: return "Martial Brace";
+                case GearType.boxingSky: return "Brace Band";
                 case GearType.jewel: return "宝玉";
 
                 default: return null;

--- a/WzComparerR2.Common/CharaSim/Translator.cs
+++ b/WzComparerR2.Common/CharaSim/Translator.cs
@@ -183,8 +183,20 @@ namespace WzComparerR2.CharaSim
 
         public static bool IsKoreanStringPresent(string checkString)
         {
-            if (checkString == null) return false;
+            if (string.IsNullOrEmpty(checkString)) return false;
             return checkString.Any(c => (c >= '\uAC00' && c <= '\uD7A3'));
+        }
+
+        public static string FullWidthKatakana(string inputString)
+        {
+            if (string.IsNullOrEmpty(inputString))
+            {
+                return inputString;
+            }
+            else
+            {
+                return inputString.Normalize(NormalizationForm.FormKC);
+            }
         }
 
         private static string GetKeyValue(string jsonDictKey)

--- a/WzComparerR2.Common/CharaSim/Translator.cs
+++ b/WzComparerR2.Common/CharaSim/Translator.cs
@@ -187,7 +187,7 @@ namespace WzComparerR2.CharaSim
             return checkString.Any(c => (c >= '\uAC00' && c <= '\uD7A3'));
         }
 
-        public static string FullWidthKatakana(string inputString)
+        public static string FullWidthKatakana(string inputString, bool ConvertHiragana=true)
         {
             if (string.IsNullOrEmpty(inputString))
             {
@@ -195,7 +195,27 @@ namespace WzComparerR2.CharaSim
             }
             else
             {
-                return inputString.Normalize(NormalizationForm.FormKC);
+                StringBuilder sb = new StringBuilder();
+
+                if (ConvertHiragana)
+                {
+                    foreach (char c in inputString)
+                    {
+                        if (c >= 'ぁ' && c <= 'ゖ')
+                        {
+                            sb.Append((char)(c + 0x60));
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+                    }
+                }
+                else
+                {
+                    sb.Append(inputString);
+                }
+                return sb.ToString().Normalize(NormalizationForm.FormKC);
             }
         }
 

--- a/WzComparerR2.MapRender/FrmMapRender2.SceneRendering.cs
+++ b/WzComparerR2.MapRender/FrmMapRender2.SceneRendering.cs
@@ -877,30 +877,24 @@ namespace WzComparerR2.MapRender
             }
 
             //计算坐标
-            Point renderSize;
-            if (back.View.Animator is FrameAnimator frameAni)
+            int cx = back.Cx;
+            int cy = back.Cy;
+            if ((back.TileMode & TileMode.BothTile) != 0 && (cx == 0 || cy == 0))
             {
-                if (back.TileMode != TileMode.None && back.Ani == 1)
+                Point renderSize = Point.Zero;
+                if (back.View.Animator is FrameAnimator frameAni)
                 {
                     renderSize = frameAni.Data.GetBound().Size;
                 }
-                else
+                else if (back.View.Animator is AnimationItem aniItem)
                 {
-                    renderSize = frameAni.CurrentFrame.Rectangle.Size;
+                    // For spine animation, we don't know how to calculate the correct cx and cy
+                    renderSize = aniItem.Measure().Size;
                 }
-            }
-            else if (back.View.Animator is AnimationItem aniItem)
-            {
-                var rect = aniItem.Measure();
-                renderSize = rect.Size;
-            }
-            else
-            {
-                renderSize = Point.Zero;
-            }
 
-            int cx = (back.Cx == 0 ? renderSize.X : back.Cx);
-            int cy = (back.Cy == 0 ? renderSize.Y : back.Cy);
+                if (cx == 0) cx = renderSize.X;
+                if (cy == 0) cy = renderSize.Y;
+            }
 
             Vector2 tileOff = new Vector2(cx, cy);
             Vector2 position = new Vector2(back.X, back.Y);

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -2503,11 +2503,14 @@ namespace WzComparerR2
 
         private IEnumerable<KeyValuePair<int, StringResult>> searchStringLinker(IEnumerable<Dictionary<int, StringResult>> dicts, string key, bool exact, bool isRegex)
         {
-            string[] match = key.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            string fullWidthKey = Translator.FullWidthKatakana(key); 
+            string[] match = (key + " " + fullWidthKey).Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
             Regex re = null;
+            Regex fullWidthRe = null;
             if (isRegex)
             {
                 re = new Regex(key, RegexOptions.IgnoreCase);
+                fullWidthRe = new Regex(fullWidthKey, RegexOptions.IgnoreCase);
             }
 
             foreach (Dictionary<int, StringResult> dict in dicts)
@@ -2516,12 +2519,12 @@ namespace WzComparerR2
                 {
                     if (exact)
                     {
-                        if (kv.Key.ToString() == key || kv.Value.Name == key)
+                        if (kv.Key.ToString() == key || kv.Value.Name == key || Translator.FullWidthKatakana(kv.Value.Name) == fullWidthKey)
                             yield return kv;
                     }
                     else if (isRegex)
                     {
-                        if (re.IsMatch(kv.Key.ToString()) || (!string.IsNullOrEmpty(kv.Value.Name) && re.IsMatch(kv.Value.Name)))
+                        if (re.IsMatch(kv.Key.ToString()) || (!string.IsNullOrEmpty(kv.Value.Name) && re.IsMatch(kv.Value.Name)) || (!string.IsNullOrEmpty(kv.Value.Name) && fullWidthRe.IsMatch(Translator.FullWidthKatakana(kv.Value.Name))))
                         {
                             yield return kv;
                         }
@@ -2532,7 +2535,7 @@ namespace WzComparerR2
                         bool r = true;
                         foreach (string str in match)
                         {
-                            if (!(id.Contains(str) || (!string.IsNullOrEmpty(kv.Value.Name) && kv.Value.Name.Contains(str))))
+                            if (!(id.Contains(str) || (!string.IsNullOrEmpty(kv.Value.Name) && kv.Value.Name.Contains(str)) || (!string.IsNullOrEmpty(kv.Value.Name) && Translator.FullWidthKatakana(kv.Value.Name).Contains(str))))
                             {
                                 r = false;
                                 break;

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -339,7 +339,7 @@ namespace WzComparerR2
                     {
                         if (wz_f.Type == e.WzType)
                         {
-                            if (e.HasChildNodes && wz_f.Node.Nodes.Count <= 0)
+                            if (wz_f.Node.Nodes.Count <= 0)
                             {
                                 continue;
                             }


### PR DESCRIPTION
- Port extended Japanese searching ability from JMS fork. You can now search items with keywords in half-width Katakana, full-width Katakana or Hiragana, or even mixed form. But Romaji cannot be converted automatically to Katakana/Hiragana/Kanji.
![image](https://github.com/user-attachments/assets/0a4a3822-0ba8-475f-969e-349b8731f1ab)

- MX weapon name is updated to match current GMS naming.
- Some upstream changes are merged.