### PR TITLE
GMS 251222 changes

### DIFF
--- a/WzComparerR2.Common/CharaSim/SummaryParser.cs
+++ b/WzComparerR2.Common/CharaSim/SummaryParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -280,7 +281,14 @@ namespace WzComparerR2.CharaSim
             {
                 if (sr.SkillH.Count > 0)
                 {
-                    h = sr.SkillH[0];
+                    if (sr.SkillExtraH.Count > 0)
+                    {
+                        h = level < sr.SkillExtraH.Keys.Min() ? sr.SkillH[0] : sr.SkillExtraH[sr.SkillExtraH.Keys.Where(k => k <= level).Max()];
+                    }
+                    else
+                    {
+                        h = sr.SkillExtraH.ContainsKey(level) ? sr.SkillExtraH[level] : sr.SkillH[0];
+                    }
                 }
 
                 if (doHighlight && DiffSkillTags != null && skillID != null)

--- a/WzComparerR2.Common/GlobalGraphicsFunction.cs
+++ b/WzComparerR2.Common/GlobalGraphicsFunction.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using WzComparerR2.WzLib;
+
+namespace WzComparerR2
+{
+    public delegate List<System.Drawing.Bitmap> GetSpineDefaultFunc(Wz_Node node);
+}

--- a/WzComparerR2.Common/StringLinker.cs
+++ b/WzComparerR2.Common/StringLinker.cs
@@ -336,6 +336,25 @@ namespace WzComparerR2.Common
                             }
                             else if (!update) strResult.SkillhcH.Add(h);
 
+                            // Precaution for GMS modifying it into Level 4 Link Skill
+                            for (int i = 3; i <= 99; i++)
+                            {
+                                string hi = GetDefaultString(linkNode, "h_" + i);
+                                if (string.IsNullOrEmpty(hi))
+                                    continue;
+                                else
+                                {
+                                    if (update && strResult.SkillExtraH.ContainsKey(i))
+                                    {
+                                        strResult.SkillExtraH[i] = hi;
+                                    }
+                                    else
+                                    {
+                                        strResult.SkillExtraH.Add(i, hi);
+                                    }
+                                }
+                            }
+
                             if (strResult.SkillH.Count > 0 && strResult.SkillH.Last() == null)
                             {
                                 strResult.SkillH.RemoveAt(strResult.SkillH.Count - 1);

--- a/WzComparerR2.Common/StringResult.cs
+++ b/WzComparerR2.Common/StringResult.cs
@@ -35,6 +35,11 @@ namespace WzComparerR2.Common
             get { return null; }
         }
 
+        public virtual Dictionary<int, string> SkillExtraH
+        {
+            get { return null; }
+        }
+
         public string this[string key]
         {
             get
@@ -83,6 +88,7 @@ namespace WzComparerR2.Common
             this.skillH = new List<string>();
             this.skillpH = new List<string>();
             this.skillhcH = new List<string>();
+            this.skillExtraH = new Dictionary<int, string>();
         }
 
         public override List<string> SkillH
@@ -100,8 +106,14 @@ namespace WzComparerR2.Common
             get { return this.skillhcH; }
         }
 
+        public override Dictionary<int, string> SkillExtraH
+        {
+            get { return this.skillExtraH; }
+        }
+
         private readonly List<string> skillH;
         private readonly List<string> skillpH;
         private readonly List<string> skillhcH;
+        private readonly Dictionary<int, string> skillExtraH;
     }
 }

--- a/WzComparerR2.WzLib/Wz_Node.cs
+++ b/WzComparerR2.WzLib/Wz_Node.cs
@@ -566,10 +566,25 @@ namespace WzComparerR2.WzLib
             return wzImg;
         }
 
-        public static void DumpAsXml(this Wz_Node node, XmlWriter writer)
+        public static void DumpAsXml(this Wz_Node node, XmlWriter writer) 
+        {
+            DumpAsXml(node, writer, null);
+        }
+
+        public static void DumpAsXml(this Wz_Node node, XmlWriter writer, IList<string> filterTags)
         {
             object value = node.Value;
 
+            // 过滤：根据 tag 名称（类名小写）匹配
+            if (filterTags != null && value != null) {
+                var currentTag = value.GetType().Name.ToLower();  // 例如 "wz_int"
+                foreach (var tag in filterTags) {
+                    if (tag != null && currentTag == tag.Trim().ToLower()) {
+                        return; // 匹配到，跳过输出
+                    }
+                }
+            }
+            
             if (value == null || value is Wz_Image)
             {
                 writer.WriteStartElement("dir");
@@ -662,7 +677,7 @@ namespace WzComparerR2.WzLib
             //输出子节点
             foreach (var child in node.Nodes)
             {
-                DumpAsXml(child, writer);
+                DumpAsXml(child, writer, filterTags);
             }
 
             //结束标识

--- a/WzComparerR2/CharaSimControl/AfrmTooltip.cs
+++ b/WzComparerR2/CharaSimControl/AfrmTooltip.cs
@@ -742,6 +742,27 @@ namespace WzComparerR2.CharaSimControl
                         }
                     }
                 }
+                else if (this.item is Npc)
+                {
+                    if ((this.TargetItem as Npc).Illustration2Bitmaps.Count == 0)
+                    {
+                        return;
+                    }
+                    using (FolderBrowserDialog dlg = new FolderBrowserDialog())
+                    {
+                        dlg.Description = "Please select a directory to save NPC Portraits.";
+                        if (dlg.ShowDialog() == DialogResult.OK)
+                        {
+                            int idx = 1;
+                            foreach (var ib in (this.TargetItem as Npc).Illustration2Bitmaps)
+                            {
+                                string fileName = $"NPC Portrait {NodeID} {NodeName} ({idx}).png";
+                                ib.Save(Path.Combine(dlg.SelectedPath, fileName), System.Drawing.Imaging.ImageFormat.Png);
+                                idx++;
+                            }
+                        }
+                    }
+                }
                 else if (this.SampleBitmap != null)
                 {
                     using (SaveFileDialog dlg = new SaveFileDialog())
@@ -873,7 +894,7 @@ namespace WzComparerR2.CharaSimControl
                         return $"#$o{sr?.Name ?? "9101069"}#";
 
                     case "M":
-                        return "モンスター";
+                        return "Monster";
 
                     case "MD":
                         Wz_Node stringNode = PluginManager.FindWz($@"String\mirrorDungeon.img\{info}\name");

--- a/WzComparerR2/CharaSimControl/NpcTooltipRenderer.cs
+++ b/WzComparerR2/CharaSimControl/NpcTooltipRenderer.cs
@@ -196,6 +196,8 @@ namespace WzComparerR2.CharaSimControl
                 g2.DrawImage(bmp, 0, 0);
                 g2.DrawImage(illustration2Tooltip, illustration2Origin);
                 g2.Dispose();
+                bmp.Dispose();
+                illustration2Tooltip.Dispose();
                 return newTooltip;
             }
             else
@@ -221,6 +223,7 @@ namespace WzComparerR2.CharaSimControl
                 int currentLineWidth = 0;
                 int currentLineHeight = 0;
                 int lineCount = 0;
+                List<int> maxLineHeights = new List<int>();
                 foreach (var bmp in bitmaps)
                 {
                     if (bmp != null)
@@ -232,6 +235,8 @@ namespace WzComparerR2.CharaSimControl
                     {
                         width = Math.Max(width, currentLineWidth);
                         height += currentLineHeight + margin;
+
+                        maxLineHeights.Add(currentLineHeight + margin);
                         currentLineWidth = 0;
                         currentLineHeight = 0;
                         lineCount++;
@@ -243,6 +248,7 @@ namespace WzComparerR2.CharaSimControl
                     height += currentLineHeight + margin;
                     currentLineWidth = 0;
                 }
+                maxLineHeights.Add(currentLineHeight + margin);
                 Bitmap result = new Bitmap(width + 30, height + 30, PixelFormat.Format32bppArgb);
                 using (Graphics g = Graphics.FromImage(result))
                 {
@@ -250,20 +256,21 @@ namespace WzComparerR2.CharaSimControl
 
                     int x = 15;
                     int y = 15;
-                    int maxLineHeight = 0;
+                    int row = 0;
+                    int maxLineHeight = maxLineHeights[0];
                     foreach (var bmp in bitmaps)
                     {
                         if (bmp != null)
                         {
-                            maxLineHeight = Math.Max(maxLineHeight, bmp.Height);
                             g.DrawImage(bmp, x, y + maxLineHeight - bmp.Height);
                             x += bmp.Width + margin;
                         }
                         if (bitmaps.IndexOf(bmp) % perLineCount == perLineCount - 1)
                         {
                             x = 15;
-                            y += maxLineHeight + margin;
-                            maxLineHeight = 0;
+                            y += maxLineHeight;
+                            if (++row <= maxLineHeights.Count - 1)
+                                maxLineHeight = maxLineHeights[row];
                         }
                     }
 

--- a/WzComparerR2/Comparer/EasyComparer.cs
+++ b/WzComparerR2/Comparer/EasyComparer.cs
@@ -2625,6 +2625,7 @@ namespace WzComparerR2.Comparer
                 npcRenderNewOld[i].StringLinker = new StringLinker();
                 npcRenderNewOld[i].StringLinker.Load(StringWzNewOld[i], ItemWzNewOld[i], EtcWzNewOld[i], QuestWzNewOld[i]);
                 npcRenderNewOld[i].ShowObjectID = this.ShowObjectID;
+                npcRenderNewOld[i].ShowAllIllustAtOnce = true;
             }
 
             foreach (var npcID in OutputNpcTooltipIDs)

--- a/WzComparerR2/Comparer/EasyComparer.cs
+++ b/WzComparerR2/Comparer/EasyComparer.cs
@@ -151,8 +151,9 @@ namespace WzComparerR2.Comparer
                     StateInfo = "Initialize V Skill Information...";
                     for (int i = 0; i < 2; i++)
                     {
-                        Wz_Node vCoreData = PluginManager.FindWz("Etc\\VcoreNew.img\\vSkill\\CoreData", WzFileNewOld[i]) ?? PluginManager.FindWz("Etc\\VCore.img\\CoreData", WzFileNewOld[i]);
-                        if (vCoreData == null) break;
+                        Wz_Node vCoreData = PluginManager.FindWz("Etc\\VcoreNew.img\\vSkill\\CoreData", WzFileNewOld[i]);
+                        if (vCoreData == null || vCoreData.FullPath == "Base.wz") vCoreData = PluginManager.FindWz("Etc\\VCore.img\\CoreData", WzFileNewOld[i]);
+                        if (vCoreData == null || vCoreData.FullPath == "Base.wz") break;
 
                         foreach (Wz_Node data in vCoreData.Nodes)
                         {

--- a/WzComparerR2/Comparer/EasyComparer.cs
+++ b/WzComparerR2/Comparer/EasyComparer.cs
@@ -151,7 +151,7 @@ namespace WzComparerR2.Comparer
                     StateInfo = "Initialize V Skill Information...";
                     for (int i = 0; i < 2; i++)
                     {
-                        Wz_Node vCoreData = PluginManager.FindWz("Etc\\VCore.img\\CoreData", WzFileNewOld[i]);
+                        Wz_Node vCoreData = PluginManager.FindWz("Etc\\VcoreNew.img\\vSkill\\CoreData", WzFileNewOld[i]) ?? PluginManager.FindWz("Etc\\VCore.img\\CoreData", WzFileNewOld[i]);
                         if (vCoreData == null) break;
 
                         foreach (Wz_Node data in vCoreData.Nodes)

--- a/WzComparerR2/Config/CharaSimNpcConfig.cs
+++ b/WzComparerR2/Config/CharaSimNpcConfig.cs
@@ -14,5 +14,12 @@ namespace WzComparerR2.Config
             get { return (bool)this["showID"]; }
             set { this["showID"] = value; }
         }
+
+        [ConfigurationProperty("showAllIllustAtOnce", DefaultValue = true)]
+        public bool ShowAllIllustAtOnce
+        {
+            get { return (bool)this["showAllIllustAtOnce"]; }
+            set { this["showAllIllustAtOnce"] = value; }
+        }
     }
 }

--- a/WzComparerR2/FrmQuickViewSetting.Designer.cs
+++ b/WzComparerR2/FrmQuickViewSetting.Designer.cs
@@ -32,6 +32,7 @@
             this.superTabControlPanel1 = new DevComponents.DotNetBar.SuperTabControlPanel();
             this.chkEnable22AniStyle = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.chkMseaMode = new DevComponents.DotNetBar.Controls.CheckBoxX();
+            this.chkShowAllIllustAtOnce = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.checkBoxX23 = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.checkBoxX21 = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.chkShowMiniMap = new DevComponents.DotNetBar.Controls.CheckBoxX();
@@ -1235,6 +1236,7 @@
             // 
             // superTabControlPanel5
             // 
+            this.superTabControlPanel5.Controls.Add(this.chkShowAllIllustAtOnce);
             this.superTabControlPanel5.Controls.Add(this.chkEnable22AniStyle);
             this.superTabControlPanel5.Controls.Add(this.chkMseaMode);
             this.superTabControlPanel5.Controls.Add(this.chkCopyParsedSkillString);
@@ -1316,6 +1318,21 @@
             this.chkMseaMode.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
             this.chkMseaMode.TabIndex = 5;
             this.chkMseaMode.Text = "MSEA Mode (incomplete)";
+            // 
+            // chkShowAllIllustAtOnce
+            // 
+            this.chkShowAllIllustAtOnce.AutoSize = true;
+            this.chkShowAllIllustAtOnce.BackColor = System.Drawing.Color.Transparent;
+            // 
+            // 
+            // 
+            this.chkShowAllIllustAtOnce.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.chkShowAllIllustAtOnce.Location = new System.Drawing.Point(13, 108);
+            this.chkShowAllIllustAtOnce.Name = "chkShowAllIllustAtOnce";
+            this.chkShowAllIllustAtOnce.Size = new System.Drawing.Size(145, 16);
+            this.chkShowAllIllustAtOnce.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.chkShowAllIllustAtOnce.TabIndex = 5;
+            this.chkShowAllIllustAtOnce.Text = "Show All NPC Portraits";
             // 
             // buttonX2
             // 
@@ -1439,6 +1456,7 @@
         private DevComponents.DotNetBar.Controls.CheckBoxX checkBoxX23;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkEnable22AniStyle;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkMseaMode;
+        private DevComponents.DotNetBar.Controls.CheckBoxX chkShowAllIllustAtOnce;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkShowDamageSkinID;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkShowDamageSkin;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkUseMiniSize;
@@ -1460,7 +1478,6 @@
         private DevComponents.DotNetBar.Controls.ComboBoxEx comboBoxEx3;
         private DevComponents.DotNetBar.Controls.ComboBoxEx comboBoxEx4;
         private DevComponents.DotNetBar.LabelX labelX4;
-
         private DevComponents.DotNetBar.Controls.ComboBoxEx cmbPreferredStringCopyMethod;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkCopyParsedSkillString;
         private DevComponents.DotNetBar.Controls.ComboBoxEx comboBoxExQuestState;

--- a/WzComparerR2/FrmQuickViewSetting.cs
+++ b/WzComparerR2/FrmQuickViewSetting.cs
@@ -299,6 +299,14 @@ namespace WzComparerR2
             set { chkShowBgmName.Checked = value; }
         }
 
+        [Link]
+        public bool Npc_ShowAllIllustAtOnce
+        {
+            get { return chkShowAllIllustAtOnce.Checked; }
+            set { chkShowAllIllustAtOnce.Checked = value; }
+        }
+
+
         public int PreferredStringCopyMethod
         {
             get

--- a/WzComparerR2/FrmSoundExport.Designer.cs
+++ b/WzComparerR2/FrmSoundExport.Designer.cs
@@ -1,0 +1,126 @@
+﻿namespace WzComparerR2
+{
+    partial class FrmSoundExport
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.lblSelectSoundIntro = new DevComponents.DotNetBar.LabelX();
+            this.clbSoundImgName = new System.Windows.Forms.CheckedListBox();
+            this.btnSelectAll = new DevComponents.DotNetBar.ButtonX();
+            this.btnReverseSelect = new DevComponents.DotNetBar.ButtonX();
+            this.btnExport = new DevComponents.DotNetBar.ButtonX();
+            this.SuspendLayout();
+            // 
+            // lblSelectSoundIntro
+            // 
+            this.lblSelectSoundIntro.AutoSize = true;
+            // 
+            // 
+            // 
+            this.lblSelectSoundIntro.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.lblSelectSoundIntro.Location = new System.Drawing.Point(10, 7);
+            this.lblSelectSoundIntro.Name = "lblSelectSoundIntro";
+            this.lblSelectSoundIntro.Size = new System.Drawing.Size(222, 16);
+            this.lblSelectSoundIntro.TabIndex = 0;
+            this.lblSelectSoundIntro.Text = "Please select the Sound IMG you'd like to export.";
+            // 
+            // clbSoundImgName
+            // 
+            this.clbSoundImgName.FormattingEnabled = true;
+            this.clbSoundImgName.Location = new System.Drawing.Point(10, 30);
+            this.clbSoundImgName.Name = "clbSoundImgName";
+            this.clbSoundImgName.Font = new System.Drawing.Font("Arial", 12F);
+            this.clbSoundImgName.Size = new System.Drawing.Size(430, 522);
+            this.clbSoundImgName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.clbSoundImgName.TabIndex = 1;
+            // 
+            // 
+            // btnSelectAll
+            // 
+            this.btnSelectAll.Location = new System.Drawing.Point(10, 550);
+            this.btnSelectAll.Name = "btnSelectAll";
+            this.btnSelectAll.Size = new System.Drawing.Size(100, 35);
+            this.btnSelectAll.TabIndex = 3;
+            this.btnSelectAll.Text = "Select All";
+            this.btnSelectAll.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground;
+            this.btnSelectAll.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.btnSelectAll.Click += new System.EventHandler(this.btnSelectAll_Click);
+            // 
+            // btnReverseSelect
+            // 
+            this.btnReverseSelect.Location = new System.Drawing.Point(174, 550);
+            this.btnReverseSelect.Name = "btnReverseSelect";
+            this.btnReverseSelect.Size = new System.Drawing.Size(100, 35);
+            this.btnReverseSelect.TabIndex = 4;
+            this.btnReverseSelect.Text = "Reverse Select";
+            this.btnReverseSelect.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground;
+            this.btnReverseSelect.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.btnReverseSelect.Click += new System.EventHandler(this.btnReverseSelect_Click);
+            // 
+            // btnExport
+            // 
+            this.btnExport.Location = new System.Drawing.Point(338, 550);
+            this.btnExport.Name = "btnExport";
+            this.btnExport.Size = new System.Drawing.Size(100, 35);
+            this.btnExport.TabIndex = 5;
+            this.btnExport.Text = "Export";
+            this.btnExport.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground;
+            this.btnExport.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.btnExport.Click += new System.EventHandler(this.btnExport_Click);
+            // 
+            // FrmSoundExport
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(450, 600);
+            this.Controls.Add(this.btnExport);
+            this.Controls.Add(this.btnReverseSelect);
+            this.Controls.Add(this.btnSelectAll);
+            this.Controls.Add(this.clbSoundImgName);
+            this.Controls.Add(this.lblSelectSoundIntro);
+            this.DoubleBuffered = true;
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "FrmSoundExport";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Export Sound";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        
+        private DevComponents.DotNetBar.LabelX lblSelectSoundIntro;
+        private System.Windows.Forms.CheckedListBox clbSoundImgName;
+        private DevComponents.DotNetBar.ButtonX btnSelectAll;
+        private DevComponents.DotNetBar.ButtonX btnReverseSelect;
+        private DevComponents.DotNetBar.ButtonX btnExport;
+    }
+}

--- a/WzComparerR2/FrmSoundExport.cs
+++ b/WzComparerR2/FrmSoundExport.cs
@@ -1,0 +1,72 @@
+﻿using DevComponents.DotNetBar;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace WzComparerR2
+{
+    public partial class FrmSoundExport : DevComponents.DotNetBar.Office2007Form
+    {
+        public FrmSoundExport(bool isDarkMode)
+        {
+            InitializeComponent();
+            if (isDarkMode)
+            {
+                this.clbSoundImgName.BackColor = System.Drawing.Color.FromArgb(-13816528);
+                this.clbSoundImgName.ForeColor = System.Drawing.Color.LightGray;
+            }
+#if NET6_0_OR_GREATER
+            // https://learn.microsoft.com/en-us/dotnet/core/compatibility/fx-core#controldefaultfont-changed-to-segoe-ui-9pt
+            this.Font = new Font(new FontFamily("Microsoft Sans Serif"), 9f);
+#endif
+        }
+
+        public string ExportFolderPath { get; private set; }
+        public List<string> SelectedSoundCodes { get; private set; }
+
+        public void AddSoundEntry(string soundImgEntry)
+        {
+            this.clbSoundImgName.Items.Add(soundImgEntry, soundImgEntry.StartsWith("Bgm"));
+        }
+
+        private void btnSelectAll_Click(object sender, EventArgs e)
+        {
+            for (int i = 0; i < this.clbSoundImgName.Items.Count; i++)
+            {
+                this.clbSoundImgName.SetItemChecked(i, true);
+            }
+        }
+
+        private void btnReverseSelect_Click(object sender, EventArgs e)
+        {
+            for (int i = 0; i < this.clbSoundImgName.Items.Count; i++)
+            {
+                this.clbSoundImgName.SetItemChecked(i, !this.clbSoundImgName.GetItemChecked(i));
+            }
+        }
+
+        private void btnExport_Click(object sender, EventArgs e)
+        {
+            if (this.clbSoundImgName.CheckedItems.Count == 0)
+            {
+                MessageBoxEx.Show("Please select at least one IMG you'd like to export.", "Sound not selected", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            FolderBrowserDialog dlg = new FolderBrowserDialog();
+            dlg.Description = "Select the destination folder you want to save to.";
+
+            if (dlg.ShowDialog() == DialogResult.OK)
+            {
+                SelectedSoundCodes = new List<string>();
+                foreach (var i in this.clbSoundImgName.CheckedItems)
+                {
+                    SelectedSoundCodes.Add(i.ToString());
+                }
+                ExportFolderPath = dlg.SelectedPath;
+                this.DialogResult = DialogResult.OK;
+            }
+        }
+    }
+}

--- a/WzComparerR2/FrmSoundExport.resx
+++ b/WzComparerR2/FrmSoundExport.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="lblSelectJobIntro.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/WzComparerR2/MainForm.Designer.cs
+++ b/WzComparerR2/MainForm.Designer.cs
@@ -265,6 +265,7 @@ namespace WzComparerR2
             this.tsmi1Export = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmi1DumpAsXml = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmi1UpdateStringLinker = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmi1ExportSound = new System.Windows.Forms.ToolStripMenuItem();
             this.nodeConnector1 = new DevComponents.AdvTree.NodeConnector();
             this.elementStyle1 = new DevComponents.DotNetBar.ElementStyle();
             this.listViewExString = new DevComponents.DotNetBar.Controls.ListViewEx();
@@ -3171,6 +3172,13 @@ namespace WzComparerR2
             this.tsmi1UpdateStringLinker.Size = new System.Drawing.Size(154, 22);
             this.tsmi1UpdateStringLinker.Text = "Update StringLinker";
             this.tsmi1UpdateStringLinker.Click += new System.EventHandler(this.tsmi1UpdateStringLinker_Click); 
+            //
+            // tsmi1ExportSound
+            // 
+            this.tsmi1ExportSound.Name = "tsmi1ExportSound";
+            this.tsmi1ExportSound.Size = new System.Drawing.Size(154, 22);
+            this.tsmi1ExportSound.Text = "Export Sound";
+            this.tsmi1ExportSound.Click += new System.EventHandler(this.tsmi1ExportSound_Click);
             // 
             // elementStyle1
             // 
@@ -3775,6 +3783,7 @@ namespace WzComparerR2
         private DevComponents.DotNetBar.ButtonItem buttonItemUpdate;
         private System.Windows.Forms.ToolStripMenuItem tsmi1DumpAsXml;
         private System.Windows.Forms.ToolStripMenuItem tsmi1UpdateStringLinker;
+        private System.Windows.Forms.ToolStripMenuItem tsmi1ExportSound;
         private DevComponents.Editors.ComboItem comboItem18;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkResolvePngLink;
         private DevComponents.DotNetBar.ComboBoxItem cmbItemSkins;

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -4734,7 +4734,7 @@ namespace WzComparerR2
 
                             // Initialize VCore Dictionary
                             Dictionary<int, List<int>> FifthJobSkillToJobID = new Dictionary<int, List<int>>();
-                            Wz_Node vCoreData = PluginManager.FindWz("Etc\\VcoreNew.img\\vSkill\\CoreData", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile()) ?? PluginManager.FindWz("Etc\\VCore.img\\CoreData", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
+                            Wz_Node vCoreData = PluginManager.FindWz("Etc\\VcoreNew.img\\vSkill\\CoreData") ?? PluginManager.FindWz("Etc\\VCore.img\\CoreData");
                             if (vCoreData != null)
                             {
                                 foreach (Wz_Node data in vCoreData.Nodes)

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -4605,7 +4605,7 @@ namespace WzComparerR2
 
                             // Initialize VCore Dictionary
                             Dictionary<int, List<int>> FifthJobSkillToJobID = new Dictionary<int, List<int>>();
-                            Wz_Node vCoreData = PluginManager.FindWz("Etc\\VCore.img\\CoreData", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
+                            Wz_Node vCoreData = PluginManager.FindWz("Etc\\VcoreNew.img\\vSkill\\CoreData", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile()) ?? PluginManager.FindWz("Etc\\VCore.img\\CoreData", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
                             if (vCoreData != null)
                             {
                                 foreach (Wz_Node data in vCoreData.Nodes)
@@ -4643,7 +4643,7 @@ namespace WzComparerR2
                             tooltip.Enable22AniStyle = Setting.Misc.Enable22AniStyle;
                             foreach (var i in selectedJob)
                             {
-                                var jobImg = PluginManager.FindWz($"Skill\\{i:D3}.img\\skill", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
+                                var jobImg = PluginManager.FindWz($"Skill\\{i:D3}.img\\skill");
                                 if (jobImg == null)
                                 {
                                     continue;
@@ -4694,7 +4694,7 @@ namespace WzComparerR2
                                     {
                                         if (kvp.Value.Contains(i))
                                         {
-                                            var skillNode = PluginManager.FindWz($"Skill\\{kvp.Key / 10000}.img\\skill\\{kvp.Key}", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
+                                            var skillNode = PluginManager.FindWz($"Skill\\{kvp.Key / 10000}.img\\skill\\{kvp.Key}");
                                             if (skillNode == null)
                                             {
                                                 continue;

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -3836,7 +3836,7 @@ namespace WzComparerR2
                 case Wz_Type.Npc:
                     if ((image = selectedNode.GetValue<Wz_Image>()) == null || !image.TryExtract())
                         return;
-                    var npc = Npc.CreateFromNode(image.Node, PluginManager.FindWz);
+                    var npc = Npc.CreateFromNode(image.Node, PluginManager.FindWz, getSpineDefaultFunc: this.pictureBoxEx1.GetSpineDefault);
                     obj = npc;
                     if (stringLinker == null || !stringLinker.StringNpc.TryGetValue(npc.ID, out sr))
                     {

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -319,7 +319,7 @@ namespace WzComparerR2
             tooltipQuickView.MapRender.ShowMiniMapMob = Setting.Map.ShowMiniMapMob;
             tooltipQuickView.MapRender.ShowMiniMapNpc = Setting.Map.ShowMiniMapNpc;
             tooltipQuickView.MapRender.ShowMiniMapPortal = Setting.Map.ShowMiniMapPortal;
-
+            tooltipQuickView.NpcRender.ShowAllIllustAtOnce = Setting.Npc.ShowAllIllustAtOnce;
             tooltipQuickView.QuestRender.ShowObjectID = Setting.Quest.ShowID;
             tooltipQuickView.QuestRender.DefaultState = Setting.Quest.DefaultState;
             tooltipQuickView.QuestRender.ShowAllStates = Setting.Quest.ShowAllStates;
@@ -3956,6 +3956,26 @@ namespace WzComparerR2
                     case Keys.OemMinus:
                     case Keys.Subtract:
                         quest.State -= 1;
+                        frm.Refresh();
+                        return;
+                }
+            }
+
+
+            Npc npc = frm.TargetItem as Npc;
+            if (npc != null)
+            {
+                switch (e.KeyCode)
+                {
+                    case Keys.Oemplus:
+                    case Keys.Add:
+                        npc.IllustIndex += 1;
+                        frm.Refresh();
+                        return;
+
+                    case Keys.OemMinus:
+                    case Keys.Subtract:
+                        npc.IllustIndex -= 1;
                         frm.Refresh();
                         return;
                 }


### PR DESCRIPTION
This pr ported NPC Portrait preview feature and Export Sound feature from JMS fork, as well as other QoL changes.

Differences from JMS fork:
- When saving samples from NPC Portrait, filename will be `NPC Portrait <npcId> <npcName> (x).png`. It's recommended to use PowerRename to change them to a suitable name before uploading to MapleStory Wiki.
- Showing all NPC Portraits is enabled by default. Users who have low resolution can disable it.
- Added support of Spine NPC Portraits (by @seotbeo ).

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/294f7247-e2d0-4a73-86a9-22322621063d" />
<img width="287" height="341" alt="image" src="https://github.com/user-attachments/assets/c70deda6-b7b7-4d3e-841f-abab92456ce3" />
<img width="1202" height="799" alt="image" src="https://github.com/user-attachments/assets/43bcce75-2e7b-413f-bf4a-083f9284a4ae" />
